### PR TITLE
fixed: No module named templatetags.admin_static in Django 3

### DIFF
--- a/jalali_date/widgets.py
+++ b/jalali_date/widgets.py
@@ -2,7 +2,7 @@
 from django.contrib.admin.widgets import AdminSplitDateTime, AdminDateWidget, AdminTimeWidget
 from django import forms
 from django.conf import settings
-from django.contrib.admin.templatetags.admin_static import static
+from django.templatetags.static import static
 from django.forms.utils import to_current_timezone
 from django.utils.html import format_html
 from django.utils.translation import ugettext as _


### PR DESCRIPTION
This error occurred becuse of path of static.py file in  Django==3.0 
ModuleNotFoundError: No module named 'django.contrib.admin.templatetags.admin_static'
