### PR TITLE
Removed 'use_2to3' in setup.py, replace '-' with '_' in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README
+description_file = README

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     long_description=read_me('README.md'),
     long_description_content_type='text/markdown',
-    use_2to3=True,
+    # use_2to3=True,
     zip_safe=False,
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
It looks like setuptools>=58 breaks support for use_2to3:

[setuptools changelog for v58](https://setuptools.readthedocs.io/en/latest/history.html#v58-0-0)

So you should update setuptools to setuptools<58 or avoid using packages with use_2to3 in the setup parameters.

Using '-' in setup.cfg warning to replace it with '_'.