### PR TITLE
Add support for Django 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /django_jalali_date.egg-info/
 
 .pypirc
+venv

--- a/jalali_date/widgets.py
+++ b/jalali_date/widgets.py
@@ -8,9 +8,9 @@ from django.utils.html import format_html
 from jdatetime import GregorianToJalali
 
 try:
-    from django.utils.translation import gettext as _  # Django >= 4
+    from django.utils.translation import gettext as _  
 except ImportError:
-    from django.utils.translation import ugettext as _  # Django < 4
+    from django.utils.translation import ugettext as _ 
 
 
 class AdminJalaliDateWidget(AdminDateWidget):

--- a/jalali_date/widgets.py
+++ b/jalali_date/widgets.py
@@ -10,7 +10,7 @@ from jdatetime import GregorianToJalali
 try:
     from django.utils.translation import ugettext as _  # Django < 4
 except ImportError:
-    from django.utils.translation import gettext as _ # Django >= 4
+    from django.utils.translation import gettext as _  # Django >= 4
 
 
 class AdminJalaliDateWidget(AdminDateWidget):

--- a/jalali_date/widgets.py
+++ b/jalali_date/widgets.py
@@ -5,8 +5,12 @@ from django.conf import settings
 from django.templatetags.static import static
 from django.forms.utils import to_current_timezone
 from django.utils.html import format_html
-from django.utils.translation import ugettext as _
 from jdatetime import GregorianToJalali
+
+try:
+    from django.utils.translation import ugettext as _
+except ImportError:
+    from django.utils.translation import gettext as _
 
 
 class AdminJalaliDateWidget(AdminDateWidget):

--- a/jalali_date/widgets.py
+++ b/jalali_date/widgets.py
@@ -8,9 +8,9 @@ from django.utils.html import format_html
 from jdatetime import GregorianToJalali
 
 try:
-    from django.utils.translation import ugettext as _  # Django < 4
-except ImportError:
     from django.utils.translation import gettext as _  # Django >= 4
+except ImportError:
+    from django.utils.translation import ugettext as _  # Django < 4
 
 
 class AdminJalaliDateWidget(AdminDateWidget):

--- a/jalali_date/widgets.py
+++ b/jalali_date/widgets.py
@@ -8,9 +8,9 @@ from django.utils.html import format_html
 from jdatetime import GregorianToJalali
 
 try:
-    from django.utils.translation import ugettext as _
+    from django.utils.translation import ugettext as _  # Django < 4
 except ImportError:
-    from django.utils.translation import gettext as _
+    from django.utils.translation import gettext as _ # Django >= 4
 
 
 class AdminJalaliDateWidget(AdminDateWidget):

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ def read_me(filename):
 setup(
     name='django-jalali-date',
     version='1.0.1',
+    python_requires='>=3',
     packages=find_packages(),
     include_package_data=True,
     description=(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read_me(filename):
 
 setup(
     name='django-jalali-date',
-    version='1.0.0',
+    version='1.0.1',
     packages=find_packages(),
     include_package_data=True,
     description=(


### PR DESCRIPTION
`django.utils.translation.ugettext` is removed in Django 4.0.

[Djnago docs](https://docs.djangoproject.com/en/4.0/releases/3.0/#s-miscellaneous)