### PR TITLE
Add support for Auto converting list_display Date/Datetime fields to jalali

### DIFF
--- a/jalali_date/admin.py
+++ b/jalali_date/admin.py
@@ -1,5 +1,8 @@
+from django.conf import settings
+from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 
+from jalali_date import date2jalali, datetime2jalali
 from jalali_date.fields import JalaliDateField, SplitJalaliDateTimeField
 from jalali_date.widgets import AdminJalaliDateWidget, AdminSplitJalaliDateTime
 
@@ -24,6 +27,39 @@ class ModelAdminJalaliMixin(object):
         formfield_overrides.update(self.formfield_overrides)
         self.formfield_overrides = formfield_overrides
         super(ModelAdminJalaliMixin, self).__init__(*args, **kwargs)
+
+    def get_list_display(self, request):
+        list_display = list(super(ModelAdminJalaliMixin, self).get_list_display(request))
+        for index, field_name in enumerate(list_display[:]):
+            try:
+                field = self.opts.get_field(field_name)
+            except FieldDoesNotExist:
+                pass
+            else:
+                func_name = 'get_jalali_' + list_display[index]
+                if isinstance(field, models.DateTimeField):
+                    list_display[index] = func_name
+                    setattr(self, func_name, self.jalali_datetime_list_display(field))
+                elif isinstance(field, models.DateField):
+                    list_display[index] = func_name
+                    setattr(self, func_name, self.jalali_date_list_display(field))
+        return list_display
+
+    def jalali_datetime_list_display(self, field):
+        def func(obj):
+            strftime = settings.JALALI_DATE_DEFAULTS['Strftime']['datetime']
+            return datetime2jalali(getattr(obj, field.name)).strftime(strftime)
+
+        func.short_description = field.verbose_name
+        return func
+
+    def jalali_date_list_display(self, field):
+        def func(obj):
+            strftime = settings.JALALI_DATE_DEFAULTS['Strftime']['date']
+            return date2jalali(getattr(obj, field.name)).strftime(strftime)
+
+        func.short_description = field.verbose_name
+        return func
 
 
 class StackedInlineJalaliMixin(object):

--- a/jalali_date/admin.py
+++ b/jalali_date/admin.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.exceptions import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist, FieldError
 from django.db import models
 
 from jalali_date import date2jalali, datetime2jalali
@@ -55,8 +55,14 @@ class ModelAdminJalaliMixin(object):
             elif isinstance(field, models.DateField):
                 strftime = settings.JALALI_DATE_DEFAULTS['Strftime']['date']
                 convert_func = date2jalali
+            else:
+                raise FieldError('The field must be an instance of DateTimeField or DateField')
 
-            return convert_func(getattr(obj, field.name)).strftime(strftime)
+            g_date = getattr(obj, field.name)
+            if not g_date:
+                return ''
+            else:
+                return convert_func(g_date).strftime(strftime)
 
         func.short_description = field.verbose_name
         return func

--- a/jalali_date/admin.py
+++ b/jalali_date/admin.py
@@ -65,6 +65,7 @@ class ModelAdminJalaliMixin(object):
                 return convert_func(g_date).strftime(strftime)
 
         func.short_description = field.verbose_name
+        func.admin_order_field = f'-{field.name}'
         return func
 
 

--- a/jalali_date/admin.py
+++ b/jalali_date/admin.py
@@ -29,6 +29,9 @@ class ModelAdminJalaliMixin(object):
         super(ModelAdminJalaliMixin, self).__init__(*args, **kwargs)
 
     def get_list_display(self, request):
+        if not settings.JALALI_DATE_DEFAULTS['LIST_DISPLAY_AUTO_CONVERT']:
+            return super(ModelAdminJalaliMixin, self).get_list_display(request)
+
         list_display = list(super(ModelAdminJalaliMixin, self).get_list_display(request))
         for index, field_name in enumerate(list_display[:]):
             try:

--- a/jalali_date/settings.py
+++ b/jalali_date/settings.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from django.conf import settings
 
 JALALI_DATE_DEFAULTS = {
+    'LIST_DISPLAY_AUTO_CONVERT': False,
     'Strftime': {
         'date': '%y/%m/%d',
         'datetime': '%H:%M:%S _ %y/%m/%d',


### PR DESCRIPTION
I overrode `get_list_display` function of `ModelAdmin` to replace date/datetime model fields in `list_display` with a callable that converts date/datetime to jalali and automatically adds `short_description` property.