### PR TITLE
added better locale settings guide for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,21 @@ JALALI_DATE_DEFAULTS = {
 
 (Optional) If you want the names of the dates to be displayed in Farsi, please add the following command to the settings.
 
+If you are on windows:
+```python
+LANGUAGE_CODE = 'fa'
+
+import locale
+locale.setlocale(locale.LC_ALL, "Persian_Iran.UTF-8")
+```
+If you are on other operating systems:
 ```python
 LANGUAGE_CODE = 'fa'
 
 import locale
 locale.setlocale(locale.LC_ALL, "fa_IR.UTF-8")
 ```
+
 
 #### views.py
 ```python


### PR DESCRIPTION
راهنمایی که برای نمایش نام ماه ها به فارسی در README.md ارائه شد بود در سیستم‌عامل ویندوز قابل استفاده نبود. راهنمای بهتر برای استفاده در سیستم‌عامل ویندوز اضافه شد.

The guide that was provided in README.md for showing months names in farsi didn't work on windows. Appropriate guide added for windows users.