### PR TITLE
[fix] #76 Remove deprecated version checks for older Django versions.

### DIFF
--- a/jalali_date/templatetags/jalali_tags.py
+++ b/jalali_date/templatetags/jalali_tags.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime
-from distutils.version import StrictVersion
 
 from django import get_version
 from django.conf import settings
@@ -7,11 +6,8 @@ from django.conf import settings
 from jalali_date import date2jalali, datetime2jalali
 from jalali_date.utils import normalize_strftime
 
-django_version = get_version()
-if StrictVersion(django_version) >= StrictVersion('1.9'):
-	from django.template import Library
-else:
-	from django.template.base import Library
+from django.template import Library
+
 
 register = Library()
 DEFAULTS = settings.JALALI_DATE_DEFAULTS

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,11 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.13',
         'Framework :: Django',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.2',
-        'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.2',
     ],
 )


### PR DESCRIPTION
Fixes issue #76 , providing python>=3.12 support without explicit need for `setuptools`.